### PR TITLE
Update README.md to remove gitlab references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,37 @@
 
 ### Cloning and Rendering the Docs Locally
 
-```bash   
-# 1. Clone the repository to your local machine:   
-git clone git@code.usgs.gov:astrogeology/asc-public-docs.git
+```bash
+# 1. Create a fork of the repository (the fork button is on the upper right corner on GitHub)
+
+# 2. Clone the repository to your local machine, replace <fork url> with your own fork.   
+git clone <fork url>
 cd asc-public-docs/
 
-# 2. Create a branch to track your work
+# 3. Create a branch to track your work
 git checkout -b your-branch-name 
 
-# 3. install dependencies 
+# 4. install dependencies 
 pip install -r requirements.txt
 
-# 4. Make your changes to the code 
+# 5. Make your changes to the code
+# See "Adding Your Files" in the readme for details
 # ...
 
-# 5. Preview your changes, in the root of the repo run
+# 6. Preview your changes, in the root of the repo run
 mkdocs serve
-
-# 6. Push your changes to the branch
-git push origin your-branch-name
 ```
 
-### Adding your files
+To contribute changes back in: 
+
+```bash
+# 1. push changes back into your fork
+git push origin your-branch-name
+
+# Create a PR on this repository 
+```
+
+### Adding Your Files
 
 > See [mkdocs material docs](https://squidfunk.github.io/mkdocs-material/getting-started/) for information on how to work with mkdoc's material theme and it's features. 
 
@@ -46,8 +55,6 @@ git push origin your-branch-name
 1. Once all the reviewers have approved your changes, one of the maintainers will merge your MR into the main branch.
 1. The continuous deployment system should automatically deploy your new changes. 
 1. Celebrate your contribution! :tada:
-
-
 
 ## Understanding The Doc System
 


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

