### PR TITLE
Added warning to skip making a release of an RC

### DIFF
--- a/docs/how-to-guides/software-management/public-release-process.md
+++ b/docs/how-to-guides/software-management/public-release-process.md
@@ -111,6 +111,10 @@ In this step, we will prepare the local repository to build from, as well as upd
 
 ### Part E: Make Github Release 
 
+!!! Warning "Do Not Make a Release for RCs"
+     
+     **Skip this step for Release Candidates (RCs).** Only pull a release if it's a full release (i.e. NOT an RC). RCs should instead be in their own branch until ready for full release.  
+
 * Draft a new github release.  
 
   * Tag the release.  


### PR DESCRIPTION
Branches of an officially released repo are considered provisional, github releases are official. By not creating a release we can avoid minting a DOI. 


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

