### PR TITLE
Added page for getting started contributing to isis

### DIFF
--- a/docs/how-to-guides/isis-developer-guides/contributing-to-isis.md
+++ b/docs/how-to-guides/isis-developer-guides/contributing-to-isis.md
@@ -1,5 +1,5 @@
 # Contributing to ISIS
-This document serves as a concise guide to contribute to ISIS.
+This document serves as a concise guide on how to contribute to ISIS.
 
 ## Build ISIS
 Begin by referring to our [Developing ISIS3 with CMake](./developing-isis3-with-cmake.md) page for instructions on setting up a local clone of ISIS and configuring an Anaconda environment for building. Once you've followed the steps outlined there, you'll have a local build of ISIS ready for development.
@@ -11,7 +11,7 @@ Navigate to the [issues page](https://github.com/DOI-USGS/ISIS3/issues) on GitHu
 Once you have completed the ticket, ensure to update the project documentation accordingly. This includes adding an entry to the CHANGELOG.md file. If your contribution introduces new classes, adhere to our [formatting documentation page](./class-requirements-for-using-doxygen-tags.md) for consistent documentation formatting.
 
 ## Test Your Changes
-Before finalizing your work, thoroughly test the code. Address any failing tests resulting from your modifications or add new tests to cover your changes. Refer to our [running tests page](./developing-isis3-with-cmake.md) for instructions on running associated tests. Additionally, learn how to write tests using Gtest and Ctest from our [writing test page](./writing-isis-tests-with-ctest-and-gtest.md).
+Before finalizing your work, thoroughly test the code. Address any failing tests resulting from your modifications or add new tests to cover your changes. Refer to our [running tests page](./developing-isis3-with-cmake.md#running-tests) for instructions on running associated tests. Additionally, learn how to write tests using Gtest and Ctest from our [writing test page](./writing-isis-tests-with-ctest-and-gtest.md).
 
 ## Create a Pull Request
 To submit your changes, commit them to your local branch using the command:

--- a/docs/how-to-guides/isis-developer-guides/contributing-to-isis.md
+++ b/docs/how-to-guides/isis-developer-guides/contributing-to-isis.md
@@ -1,0 +1,19 @@
+# Contributing to ISIS
+This document serves as a concise guide to contribute to ISIS.
+
+## Build ISIS
+Begin by referring to our [Developing ISIS3 with CMake](./developing-isis3-with-cmake.md) page for instructions on setting up a local clone of ISIS and configuring an Anaconda environment for building. Once you've followed the steps outlined there, you'll have a local build of ISIS ready for development.
+
+## Pick an Issue
+Navigate to the [issues page](https://github.com/DOI-USGS/ISIS3/issues) on GitHub, where you'll find a variety of bugs and feature requests. To identify suitable tasks for beginners, filter the issues using the "good first issue" label. You can access these labeled issues directly [here](https://github.com/DOI-USGS/ISIS3/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). Once you've chosen an issue, click on its title to view details, and assign yourself to it by selecting "assign yourself" under the "Assignees" section on the right side of the issue description.
+
+## Document Your Changes
+Once you have completed the ticket, ensure to update the project documentation accordingly. This includes adding an entry to the CHANGELOG.md file. If your contribution introduces new classes, adhere to our [formatting documentation page](./class-requirements-for-using-doxygen-tags.md) for consistent documentation formatting.
+
+## Test Your Changes
+Before finalizing your work, thoroughly test the code. Address any failing tests resulting from your modifications or add new tests to cover your changes. Refer to our [running tests page](./developing-isis3-with-cmake.md) for instructions on running associated tests. Additionally, learn how to write tests using Gtest and Ctest from our [writing test page](./writing-isis-tests-with-ctest-and-gtest.md).
+
+## Create a Pull Request
+To submit your changes, commit them to your local branch using the command:
+`git commit -m “<message>”` where <message> is your commit message. Then, push up your changes to your fork 
+`git push origin <branch_name>` where `<branch_name>` is the name of your local branch you made your changes on. Finally, head over to your fork, click on the “Branch” dropdown, select the branch `<branch_name>` from the dropdown, and click “New Pull Request”. Give your PR a descriptive but brief title and fill out the description skeleton. After submitting your PR, wait for someone to review it, and make any necessary changes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Guidelines for Pull Requests:      how-to-guides/software-management/guidelines-for-pull-requests.md
       - ISIS Release Schedule:             how-to-guides/software-management/isis-release-schedule.md
     - ISIS Developer Guides:
+      - Getting Started Contributing to ISIS:         how-to-guides/isis-developer-guides/contributing-to-isis.md
       - How To Write ISIS Tests with CTest and GTest: how-to-guides/isis-developer-guides/writing-isis-tests-with-ctest-and-gtest.md
       - App Testing CookBook:                         how-to-guides/isis-developer-guides/app-testing-cookbook.md
       - Class Requirements For Using Doxygen Tags:    how-to-guides/isis-developer-guides/class-requirements-for-using-doxygen-tags.md


### PR DESCRIPTION
Closes #17 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

