### PR TITLE
Update ISIS release process for full feature releases

### DIFF
--- a/docs/how-to-guides/software-management/public-release-process.md
+++ b/docs/how-to-guides/software-management/public-release-process.md
@@ -22,14 +22,13 @@ In this step, we check the currently failing tests. This is currently a judgemen
 
 ### Step 2: Update the GitHub documents
 
-**This step is only required for release candidates and bug fix release. If you are creating a full feature release, skip this step.**
-
 In this step, we will update the documents that are stored in the GitHub repository. Our changes will be going into the dev branch, so create a fresh local branch off of the dev branch.
 
 
 #### Part A: Collecting the Changes in the Release
 
 * Update the Changelog 
+  * For full feature releases, we need to update the release date to the day it is being officially released. All the cumulative changes in this release should have already been appropriately added in iterative release candidates leading up to the full feature release.
   * For release candidates we need to update the Changelog to label all the currently unreleased changes as part of this release. Follow the instructions in [CHANGELOG.md](https://raw.githubusercontent.com/DOI-USGS/ISIS3/dev/CHANGELOG.md) for how to do this.
   * For bug fix releases, we need to update the Changelog to label **only the bug fixes** as part of this release. Follow the instructions in [CHANGELOG.md](https://raw.githubusercontent.com/DOI-USGS/ISIS3/dev/CHANGELOG.md) for how to do this.
 * Update `code.json` by adding a new entry with the new version number and the date last modified.


### PR DESCRIPTION
Changes:

- Updated to remove the note that Step 2 of the ISIS public release process only applies to RCs and bug fix releases.
- Added that the release date in the CHANGELOG.md should be updated.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

