### PR TITLE
setting PATH in env vars section

### DIFF
--- a/docs/how-to-guides/environment-setup-and-maintenance/installing-isis-via-anaconda.md
+++ b/docs/how-to-guides/environment-setup-and-maintenance/installing-isis-via-anaconda.md
@@ -113,6 +113,10 @@ ISIS requires these environment variables to be set in order to run correctly:
 - `ISISROOT` - Directory path containing your ISIS install
 - `ISISDATA` - Directory path containing the [ISIS Data Area](../../how-to-guides/environment-setup-and-maintenance/isis-data-area.md)
 
+We also recommend setting:
+
+- `PATH` - Where your computer looks for runnable apps, including ISIS apps.
+
 ???+ example "Setting Environmental Variables"
 
     The **Conda Env** method is recommended, and the **Python Script** automates that method:
@@ -139,9 +143,9 @@ ISIS requires these environment variables to be set in order to run correctly:
             # conda config vars set KEY=VALUE
             ```
 
-        1.  This command sets both required variables (fill in your `ISISDATA` path):
+        1.  This command sets both required variables and the PATH (fill in your `ISISDATA` location):
 
-                conda env config vars set ISISROOT=$CONDA_PREFIX ISISDATA=[your data path]
+                conda env config vars set ISISROOT=$CONDA_PREFIX ISISDATA=[your data path] PATH=$CONDA_PREFIX/bin:$PATH
 
         1.  Re-activate your isis environment. 
             ```sh
@@ -154,6 +158,10 @@ ISIS requires these environment variables to be set in order to run correctly:
 
     === "Python Script"
 
+        You should have your conda environment active before running this script:
+        
+            conda activate isis
+        
         By default, running this script will set `ISISROOT=$CONDA_PREFIX` and `ISISDATA=$CONDA_PREFIX/data`:
 
             python $CONDA_PREFIX/scripts/isisVarInit.py
@@ -161,6 +169,10 @@ ISIS requires these environment variables to be set in order to run correctly:
         You can specify a different path for `$ISISDATA` using the optional value:
 
             python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]
+
+        Optionally, set the path variable:
+
+            conda env config vars set PATH=$CONDA_PREFIX/bin:$PATH
 
         Now every time the isis environment is activated, `$ISISROOT` and `$ISISDATA` will be set to the values passed to isisVarInit.py.
         This does not happen retroactively, so re-activate the isis environment:
@@ -176,6 +188,7 @@ ISIS requires these environment variables to be set in order to run correctly:
         ```sh
         export ISISROOT=[path to ISIS]
         export ISISDATA=[path to data]
+        export PATH=[path to ISIS]/bin:$PATH
         ```
 
 


### PR DESCRIPTION
## Licensing

Adds instructions on how to set your PATH when installing ISIS.

Fixes #128 

This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

