### PR TITLE
Added spiceql

### DIFF
--- a/docs/manuals/index.md
+++ b/docs/manuals/index.md
@@ -29,4 +29,9 @@ hide:
   url:     ./plio/
   image:   https://raw.githubusercontent.com/DOI-USGS/plio/main/docs/PLIO_Logo.svg
 
+- title:   SpiceQL
+  content: Spice Query Library
+  url:     ./spiceql/
+  image:   https://github.com/DOI-USGS/SpiceQL/blob/c3cd99a0660c14d8e31927bd25cc5d38315375cb/docs/assets/banner3.png?raw=true
+
 ::/cards::


### PR DESCRIPTION
Adds SpiceQL docs to manuals. Using the existing banner for now, we should probably update some of these. Also fixes ISIS's logo. 

I
<img width="991" alt="Screenshot 2025-03-07 at 2 44 56 PM" src="https://github.com/user-attachments/assets/aaa584a1-40d8-49c9-830a-14c6ac4fbfbf" />



## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

