### PR TITLE
Deprecation Procedure for ISIS

### DIFF
--- a/docs/concepts/isis-fundamentals/preference-dictionary.md
+++ b/docs/concepts/isis-fundamentals/preference-dictionary.md
@@ -59,12 +59,13 @@ EndGroup
 
 ## Error Facility
 
-Errors can be written in either standard (single line) or PVL format, with the option to suppress the source file and line number identifying where the error occurred. Additionally, stack traces can be displayed when running ISIS in debug mode.
+Errors can be written in either **standard** (single line) or **PVL** format, with the option to suppress the source file and line number identifying where the error occurred.  Deprecation warnings can be shown or hidden.  Additionally, stack traces can be displayed when running ISIS in debug mode.
 
 ```
 Group = ErrorFacility
   Format   = Standard | Pvl
   FileLine = On | Off
+  ShowDeprecated = On | Off
   StackTrace = On | Off
 EndGroup
 ```

--- a/docs/how-to-guides/software-management/deprecation.md
+++ b/docs/how-to-guides/software-management/deprecation.md
@@ -5,7 +5,43 @@ This document is intended to provide guidelines for the deprecation process.
 Those who wish to deprecate functionality should propose the deprecation via an issue on the software's repository of record.  This allows for discussion among the developers and the user community.  If a consensus is met that the functionality should be deprecated, then a deprecation warning should be written.
 
 ## 2. Deprecation Warning
-A deprecation warning should be presented to the user whenever the deprecated functionality is used.  Though no standard has yet been agreed upon by the developers or the ASC software user base, previous deprecation warnings have taken the form of a simple message printed via `cout`.  In addition to creating the deprecation warning message, the deprecated functionality should also be noted in the repository's changelog.  This warning should include a link to the issue that proposed the deprecation.
+A deprecation warning should be presented to the user whenever the deprecated functionality is used.  Check below for procedures for particular software  There is not yet a standard procedure for deprecation across all Astro software.  Previous deprecation warnings have taken the form of a simple message printed via `cout`.  In addition to creating the deprecation warning message, the deprecated functionality should also be noted in the repository's changelog.  This warning should include a link to the issue that proposed the deprecation.
+
+### Deprecation Warnings in ISIS
+
+In ISIS:
+- Deprecation warnings can be **enabled**, or **hidden**, by the `ErrorFacility > ShowDeprecated` switch in the [Isispreferences](../../concepts/isis-fundamentals/preference-dictionary.md) file.
+  - This preference setting must be checked before printing a deprecation warning.
+- Deprecation warnings are printed to `std::cerr`.
+
+
+```cpp
+#include "Preference.h"
+
+// ...
+
+void MyIsisObject::deprecatedMethod() {
+    
+    bool outputDeprecated = true;
+    if (Preference::Preferences().hasGroup("ErrorFacility")) {
+        PvlGroup &errorFacility =
+            Preference::Preferences().findGroup("ErrorFacility");
+        if (errorFacility.hasKeyword("ShowDeprecated")) {
+        QString showDeprecatedSetting = errorFacility["ShowDeprecated"][0];
+        outputDeprecated = (showDeprecatedSetting.toUpper() == "ON");
+        }
+    }
+                    
+    if (outputDeprecated) {
+        QString msg = "This function (MyIsisObject::deprecatedMethod) will be deprecated in ISIS [version] "
+                      "in favor of someIsisObject::replacementMethod";
+
+        std::cerr << msg << std::endl;
+    }
+
+// The rest of the method
+};
+```
 
 ## 3. Removal of Deprecated Functionality
 No less than 6 months after the release that includes the deprecation notice, a commit containing the removal of the deprecated functionality should be PR'd into the development branch.  This change should also be captured in the changelog.

--- a/docs/how-to-guides/software-management/deprecation.md
+++ b/docs/how-to-guides/software-management/deprecation.md
@@ -18,24 +18,12 @@ In ISIS:
 
 ```cpp
 #include "Preference.h"
-
 // ...
-
 void MyIsisObject::deprecatedMethod() {
     
-    bool outputDeprecated = true;
-    if (Preference::Preferences().hasGroup("ErrorFacility")) {
-        PvlGroup &errorFacility =
-            Preference::Preferences().findGroup("ErrorFacility");
-        if (errorFacility.hasKeyword("ShowDeprecated")) {
-        QString showDeprecatedSetting = errorFacility["ShowDeprecated"][0];
-        outputDeprecated = (showDeprecatedSetting.toUpper() == "ON");
-        }
-    }
-                    
-    if (outputDeprecated) {
-        QString msg = "This function (MyIsisObject::deprecatedMethod) will be deprecated in ISIS [version] "
-                      "in favor of someIsisObject::replacementMethod";
+    if (Preference::Preferences().getShowDeprecatedPref()) {
+        QString msg = "This function (MyIsisObject::deprecatedMethod) will be deprecated "
+                      "in ISIS [version], in favor of someIsisObject::replacementMethod.";
 
         std::cerr << msg << std::endl;
     }

--- a/docs/how-to-guides/software-management/deprecation.md
+++ b/docs/how-to-guides/software-management/deprecation.md
@@ -5,13 +5,13 @@ This document is intended to provide guidelines for the deprecation process.
 Those who wish to deprecate functionality should propose the deprecation via an issue on the software's repository of record.  This allows for discussion among the developers and the user community.  If a consensus is met that the functionality should be deprecated, then a deprecation warning should be written.
 
 ## 2. Deprecation Warning
-A deprecation warning should be presented to the user whenever the deprecated functionality is used.  Check below for procedures for particular software  There is not yet a standard procedure for deprecation across all Astro software.  Previous deprecation warnings have taken the form of a simple message printed via `cout`.  In addition to creating the deprecation warning message, the deprecated functionality should also be noted in the repository's changelog.  This warning should include a link to the issue that proposed the deprecation.
+A deprecation warning should be presented to the user whenever the deprecated functionality is used.  Check below for procedures for particular software.  There is not yet a standard procedure for deprecation across all Astro software.  Previous deprecation warnings have taken the form of a simple message printed via `cout`.  In addition to creating the deprecation warning message, the deprecated functionality should also be noted in the repository's changelog.  This warning should include a link to the issue that proposed the deprecation.
 
 ### Deprecation Warnings in ISIS
 
 In ISIS:
 
-- Deprecation warnings can be **enabled** (On), or **hidden** (Off), by the `ErrorFacility > ShowDeprecated` switch in the [Isispreferences](../../concepts/isis-fundamentals/preference-dictionary.md) file.
+- Deprecation warnings can be **enabled** (On), or **hidden** (Off), by the `ErrorFacility > ShowDeprecated` switch in the [IsisPreferences](../../concepts/isis-fundamentals/preference-dictionary.md) file.
     - This preference setting must be checked before printing a deprecation warning.
 - Deprecation warnings are printed to `std::cerr`.
 

--- a/docs/how-to-guides/software-management/deprecation.md
+++ b/docs/how-to-guides/software-management/deprecation.md
@@ -10,8 +10,9 @@ A deprecation warning should be presented to the user whenever the deprecated fu
 ### Deprecation Warnings in ISIS
 
 In ISIS:
-- Deprecation warnings can be **enabled**, or **hidden**, by the `ErrorFacility > ShowDeprecated` switch in the [Isispreferences](../../concepts/isis-fundamentals/preference-dictionary.md) file.
-  - This preference setting must be checked before printing a deprecation warning.
+
+- Deprecation warnings can be **enabled** (On), or **hidden** (Off), by the `ErrorFacility > ShowDeprecated` switch in the [Isispreferences](../../concepts/isis-fundamentals/preference-dictionary.md) file.
+    - This preference setting must be checked before printing a deprecation warning.
 - Deprecation warnings are printed to `std::cerr`.
 
 


### PR DESCRIPTION
First merge the Sister PR: DOI-USGS/ISIS3#5770

Then merge this one.

Closes DOI-USGS/ISIS3#5611

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

