### PR TITLE
Added llms.txt generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: USGS Astrogeology Software Docs
+site_url: https://astrogeology.usgs.gov/docs/
 
 theme:
     name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,21 @@ extra_javascript:
 
 plugins:
   - search
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        Getting Started:
+          - getting-started/index.md : index page for getting started
+          - getting-started/* : tutorials used by new users looking for how to get started
+        How-To Guides:
+          - how-to-guides/index.md : index page for how-to-guides
+          - how-to-guides/* : how-to-guides
+        Concepts:
+          - concepts/index.md : index page for concepts
+          - concepts/* : concepts
+        Manuals:
+          - manuals/index.md : index page for manuals
+          - manuals/* : manuals
   - mknotebooks: 
       include_source: True
   - mermaid2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,16 +165,16 @@ plugins:
       sections:
         Getting Started:
           - getting-started/index.md : index page for getting started
-          - getting-started/* : tutorials used by new users looking for how to get started
+          - getting-started/* : Tutorials used by new users looking for how to get started
         How-To Guides:
           - how-to-guides/index.md : index page for how-to-guides
-          - how-to-guides/* : how-to-guides
+          - how-to-guides/* : how-to-guides, including environment setup and maintenance, SPICE, image processing, ISIS demos, software management, ISIS developer guides, ALE developer guides
         Concepts:
           - concepts/index.md : index page for concepts
-          - concepts/* : concepts
+          - concepts/* : concepts, including camera geometry and projections, ISIS fundamentals, SPICE, image processing, control networks, sensor models, history
         Manuals:
           - manuals/index.md : index page for manuals
-          - manuals/* : manuals
+          - manuals/* : manuals, including ISIS, ALE, and other software manuals
   - mknotebooks: 
       include_source: True
   - mermaid2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ codespell
 linkchecker
 mkdocs-redirects
 git+https://github.com/Kelvinrr/mknotebooks.git
+mkdocs-llmstxt


### PR DESCRIPTION
This should (theoretically) help LLMs search our docs for information. It's at least an emerging standard that is very low effort to implement. 

See https://llmstxt.org 

This creates an `llms.txt` file that indexes our docs in plain markdown and `llms-full.txt` that puts all our docs into one markdown page. 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

