### PR TITLE
CI/CD Blurbs in release

### DIFF
--- a/docs/how-to-guides/software-management/releases/isis-release-process.md
+++ b/docs/how-to-guides/software-management/releases/isis-release-process.md
@@ -56,7 +56,7 @@ Subsequent Production and LTS releases (with no Major version change, i.e, 8.***
 
 ??? example "CI/CD: Cherry-Picking"
 
-    `gitub-cherrypick.yml` attempts to auto-cherrypick bugfixes to the next LTS branch, and bugfixes + non-breaking features to the next Prod branch, as the changes are merged into the Dev branch.  Identifies bugfixes and/or non-breaking features by the checkboxes from the PR template.  Not all changes are automatically resolveable, so make sure to manually cherry-pick any remaining changes that need to be included in LTS or Prod.
+    [`gitub-cherrypick.yml`](https://github.com/DOI-USGS/ISIS3/blob/dev/.github/workflows/github-cherrypick.yml) attempts to auto-cherrypick bugfixes to the next LTS branch, and bugfixes + non-breaking features to the next Prod branch, as the changes are merged into the Dev branch.  Identifies bugfixes and/or non-breaking features by the checkboxes from the PR template.  Not all changes are automatically resolveable, so make sure to manually cherry-pick any remaining changes that need to be included in LTS or Prod.
 
     Triggered by pushes (including merged-PRs) to dev.
 
@@ -72,7 +72,7 @@ Check the [AWS CodeBuild test results](https://us-west-2.codebuild.aws.amazon.co
 
 ??? example "CI/CD: Codebuild"
 
-    `gitlab-codebuild.yml` auto-builds ISIS to check for build and/or test failures.  The auto-build runs in a linux system, so this is a good chance to check for errors that may not occur in a local mac build.
+    [`gitlab-codebuild.yml`](https://github.com/DOI-USGS/ISIS3/blob/dev/.github/workflows/gitlab-codebuild.yml) auto-builds ISIS to check for build and/or test failures.  The auto-build runs in a linux system, so this is a good chance to check for errors that may not occur in a local mac build.
 
     Triggered by the creation of a PR to any branch.  Makes a push to the internal isis-codebuild-ci repo, and lets that repo's CI/CD do the rest of the work (i.e. talking to AWS codebuild).
 
@@ -201,7 +201,7 @@ Clone the repo locally with git clone.
     - [ ] Name the release "ISISX.Y.Z Production". 
 
 ??? example "CI/CD: Conda Release"
-    `github-release.yml` builds ISIS (with kakadu) and uploads those builds to conda.  It also updates the ISIS Docs for the release version.
+    [`github-release.yml`](https://github.com/DOI-USGS/ISIS3/blob/dev/.github/workflows/github-release.yml) builds ISIS (with kakadu) and uploads those builds to conda.  It also updates the ISIS Docs for the release version.
 
     Triggered by GitHub Releases, pushes to `*.*.*_RC*` or `*.*.*_LTS` branches, or manually.
     
@@ -210,6 +210,8 @@ Clone the repo locally with git clone.
     - Make sure the images this action relies on are up to date.
     Only the most recent two mac versions are supported, 
     and an out of date mac image will cause this action to fail. 
+
+    [`dev-weekly-release.yml`](https://github.com/DOI-USGS/ISIS3/blob/dev/.github/workflows/dev-weekly-release.yml) makes a dev build of ISIS each week and uploads it to conda.
 
 !!! note ""
 


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

