### PR TITLE
Fix broken link to SpiceQL Cassini Notebook

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -70,7 +70,7 @@ SpiceQL is a library for indexing and querying information from spacecraft SPICE
 
     Get positional data for the Cassini Spacecraft.
 
-    [:octicons-arrow-right-24: Make a simple query](../how-to-guides/environment-setup-and-maintenance/installing-isis-via-anaconda.md)
+    [:octicons-arrow-right-24: Make a simple query](../getting-started/using-spiceql/spiceql-cassini-tutorial.ipynb)
 
 -   :material-list-box:{ .lg .middle } __SpiceQL API__
 


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

