### PR TITLE
towncrier ISIS release notes

### DIFF
--- a/docs/how-to-guides/software-management/releases/isis-release-process.md
+++ b/docs/how-to-guides/software-management/releases/isis-release-process.md
@@ -96,6 +96,9 @@ Check the [AWS CodeBuild test results](https://us-west-2.codebuild.aws.amazon.co
     - [ ] **Update the Authors List**:  If there are any new contributors to the project since the last release, update the `AUTHORS.rst` file to include them.
     - [ ] Submit a Pull Request: Submit a pull request into the Prod release feeder branch (i.e, `9-prod`). 
 
+!!! info ""
+
+    If needed, install towncrier with `conda install towncrier`
 
 !!! Success "" 
     


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

