### PR TITLE
Add Chandrayaan 2 OHRC ingestion page and fix the conda install command

### DIFF
--- a/docs/concepts/missions/chandrayaan2/index.md
+++ b/docs/concepts/missions/chandrayaan2/index.md
@@ -142,8 +142,9 @@ are included and should be autodetected in ISIS versions 10.0 and above.
 
 ## Further Chandrayaan 2 Examples:
 
-- [Chandrayaan 2 TMC-2 Images in Knoten - Astro Docs Jupyter Notebook](../../../getting-started/csm-stack/ingesting-tmc2.md)
-- [Chandrayaan 2 OHRC - Ames Stereo Pipeline](https://stereopipeline.readthedocs.io/en/latest/examples/chandrayaan2.html)
+- [Processing Chandrayaan 2 TMC-2 Images - Astro Docs](../../../getting-started/csm-stack/ingesting-tmc2.md)
+- [Processing Chandrayaan 2 OHRC Images - Astro Docs](../../../getting-started/csm-stack/ingesting-ohrc.md)
+- [Chandrayaan 2 Stereo - Ames Stereo Pipeline](https://stereopipeline.readthedocs.io/en/latest/examples/chandrayaan2.html)
 
 ## Sources
 

--- a/docs/getting-started/csm-stack/ingesting-ohrc.md
+++ b/docs/getting-started/csm-stack/ingesting-ohrc.md
@@ -1,0 +1,136 @@
+# Processing Chandrayaan 2 OHRC Images
+
+More info on Chandrayaan 2:
+
+- [Chandrayaan 2 Mission - USGS Astro](https://astrogeology.usgs.gov/docs/concepts/missions/chandrayaan2)
+- [Processing Chandrayaan 2 TMC-2 Images](ingesting-tmc2.md)
+- [Chandrayaan 2 Stereo - Ames Stereo Pipeline](https://stereopipeline.readthedocs.io/en/latest/examples/chandrayaan2.html)
+
+The OHRC (Orbiter High Resolution Camera) is a panchromatic pushbroom camera
+with a ground sample distance of about 0.25 m. The ingestion workflow is the
+same as for [TMC-2](ingesting-tmc2.md), with one intentional difference in how
+the SPICE kernels are sourced (see the note below).
+
+### Environment
+
+You will need:
+
+* ISIS 10.0.0_RC2
+* ALE >= 1.1.3
+* SpiceQL >= 1.2.7
+* usgscsm
+
+To install these with conda:
+```sh
+conda create -n ch2 \
+    -c usgs-astrogeology/label/RC \
+    -c conda-forge \
+    matplotlib isis=10.0.0_RC2 ale=1.1.3 usgscsm=2.0.2
+conda activate ch2 # activate env
+```
+
+!!! Note "ISIS 10 release candidate"
+
+    ISIS 10 has not been formally released yet, so the command above installs the
+    `10.0.0_RC2` release candidate from the `usgs-astrogeology/label/RC` channel.
+
+### Image Data, Label, and Template
+
+The `.img` image and `.xml` label are required to import an OHRC image into the
+ISIS cube format. These can be downloaded from [ISRO's interactive map](https://chmapbrowse.issdc.gov.in)
+or [ISRO's PRADAN system for bulk downloads](https://pradan.issdc.gov.in/ch2/protected/payload.xhtml).
+(New users must register an account.)
+
+!!! Note "SPICE Kernel Coverage"
+
+    Chandrayaan 2 SPICE kernels are distributed through the ISIS data area and
+    fetched with `downloadIsisData chandrayaan2 $ISISDATA` (see the next section).
+    Coverage may still lag for the most recent acquisitions. You can check which
+    kernels are available with the following CURL command:
+
+    ```bash
+    curl -XGET "https://astrogeology.usgs.gov/apis/spiceql/latest/searchForKernelsets?spiceqlNames=\[chandrayaan2\]&limitCk=-1&limitSpk=-1" | jq
+    ```
+
+    The filenames for CKs and SPKs tell you their time coverage.
+
+### Set Environmental Variables
+
+ISIS requires `ISISROOT` and `ISISDATA` to be set. You can set `ISISROOT` equal
+to the `CONDA_PREFIX`. You will need to [set up the ISIS Data Area](https://astrogeology.usgs.gov/docs/how-to-guides/environment-setup-and-maintenance/isis-data-area/)
+and set `ISISDATA` to point to it, with at least the `base` and `chandrayaan2`
+areas installed:
+
+```bash
+downloadIsisData base $ISISDATA
+downloadIsisData chandrayaan2 $ISISDATA
+```
+
+### Create an ISIS compatible Cube or GTiff
+
+Import the image with `isisimport`, attach the kernels with `spiceinit`, then
+create the ISD with `isd_generate`:
+
+```sh
+isisimport from=ch2_ohr_ncp_20211228T2209123959_d_img_d18.xml to=ch2_ohr_ncp_20211228T2209123959_d_img_d18.cub
+spiceinit from=ch2_ohr_ncp_20211228T2209123959_d_img_d18.cub
+# create an ISD; this writes ch2_ohr_ncp_20211228T2209123959_d_img_d18.json
+isd_generate -k ch2_ohr_ncp_20211228T2209123959_d_img_d18.cub ch2_ohr_ncp_20211228T2209123959_d_img_d18.cub
+```
+
+!!! Note "Why OHRC uses `spiceinit` and `isd_generate -k`"
+
+    Unlike the [TMC-2 workflow](ingesting-tmc2.md), which reads kernels from the
+    local data area with `isd_generate -s`, OHRC runs `spiceinit` first and then
+    `isd_generate -k`. For OHRC, `spiceinit` cleanly attaches the SPICE kernels to
+    the cube, so `-k` reads them directly from the cube. This is the most
+    reproducible path from a fresh `downloadIsisData`, as it does not require any
+    local metakernel setup. The `-s` approach used for TMC-2 also works if you
+    prefer to read kernels from the local `ISISDATA` area.
+
+    The cube name appears twice on purpose: `-k <cube>` points `isd_generate` at
+    the SPICE kernels attached by `spiceinit`, and the second occurrence is the
+    input image the ISD is generated for.
+
+    You can troubleshoot `isd_generate` with `-v`. The most common issue is
+    missing kernels covering the image's time range.
+
+Check you have the files; you will need the `.json` and `.cub`:
+
+```
+ls -1
+# ch2_ohr_ncp_20211228T2209123959_d_img_d18.cub
+# ch2_ohr_ncp_20211228T2209123959_d_img_d18.img
+# ch2_ohr_ncp_20211228T2209123959_d_img_d18.json
+# ch2_ohr_ncp_20211228T2209123959_d_img_d18.xml
+```
+
+From here you can use the `.cub` and `.json` for any CSM compatible tool like
+Socet GXP or Ames Stereo Pipeline.
+
+### Create an ISIS-compatible image
+
+To use this image in ISIS, you will need to combine the JSON ISD with the cube.
+These can be written as an ISIS Cube or GTiff. We recommend GTiffs given the
+large size of CH2 images.
+
+```
+mamba install usgscsm # if not installed already
+csminit from=ch2_ohr_ncp_20211228T2209123959_d_img_d18.cub isd=ch2_ohr_ncp_20211228T2209123959_d_img_d18.json
+cubeatt from=ch2_ohr_ncp_20211228T2209123959_d_img_d18.cub to=ch2_ohr_ncp_20211228T2209123959_d_img_d18.tiff+GTIFF
+```
+
+You can view the image with `qview`, `qgis`, or other tools designed for spatial
+data. The image is large and may take a moment to render.
+
+```bash
+qview ch2_ohr_ncp_20211228T2209123959_d_img_d18.tiff
+```
+
+From here you can use the image in other ISIS apps such as `footprintinit` and
+`cam2map`. Initial pointing in OHRC has errors (as with most instruments), so
+bundle adjustment is necessary for accuracy.
+
+See for bundle adjustment info: https://astrogeology.usgs.gov/docs/how-to-guides/image-processing/bundle-adjustment-in-isis/
+
+See for OHRC stereo info in ASP: https://stereopipeline.readthedocs.io/en/latest/examples/chandrayaan2.html

--- a/docs/getting-started/csm-stack/ingesting-tmc2.md
+++ b/docs/getting-started/csm-stack/ingesting-tmc2.md
@@ -3,46 +3,40 @@
 More info on Chandrayaan 2:
 
 - [Chandrayaan 2 Mission - USGS Astro](https://astrogeology.usgs.gov/docs/concepts/missions/chandrayaan2)
-- [OHRC Images - Ames Stereo Pipeline](https://stereopipeline.readthedocs.io/en/latest/examples/chandrayaan2.html)
+- [Processing Chandrayaan 2 OHRC Images](ingesting-ohrc.md)
+- [Chandrayaan 2 Stereo - Ames Stereo Pipeline](https://stereopipeline.readthedocs.io/en/latest/examples/chandrayaan2.html)
 
 ### Environment 
 
 You will need: 
 
-* ALE >= 1.1.2
-* ISIS >= 10.0.0 
+* ISIS 10.0.0_RC2
+* ALE >= 1.1.3
 * SpiceQL >= 1.2.7
 * usgscsm 
 
 To install these with conda:
 ```sh
 conda create -n ch2 \
-    -c conda-forge -c usgs-astrogeology \
-    matplotlib ale=1.1.2 "usgs-astrogeology/label/RC::isis>=10.0.0"
+    -c usgs-astrogeology/label/RC \
+    -c conda-forge \
+    matplotlib isis=10.0.0_RC2 ale=1.1.3 usgscsm=2.0.2
 conda activate ch2 # activate env
 ```
 
-!!! Warning
-   
-    As of writing, the latest version of ISIS that supports Chandrayaan-2 is ISIS 10.0.0 RC1, once ISIS 10.0.0 is out of release candidate (RC) status, you can download it with the command:
+!!! Note "ISIS 10 release candidate"
 
-    ```sh
-    conda create -n ch2 \
-        -c conda-forge -c usgs-astrogeology \
-        matplotlib ale=1.1.2 SpiceQL >= 1.2.7 "usgs-astrogeology::isis>=10.0.0_RC1"
-    conda activate ch2 # activate env
-    ```
+    ISIS 10 has not been formally released yet, so the command above installs the
+    `10.0.0_RC2` release candidate from the `usgs-astrogeology/label/RC` channel.
 
 
 ### Image Data, Label, and Template
 
 The `.img` image and `.xml` label are required to import a TMC image into the ISIS cube format.  These can be downloaded [ISRO's interactive map](https://chmapbrowse.issdc.gov.in) or [ISRO's PRADAN system for bulk downloads](https://pradan.issdc.gov.in/ch2/protected/payload.xhtml).  (New users must register an account.)
 
-!!! Warning "Spice Kernel Coverage"
+!!! Note "SPICE Kernel Coverage"
 
-    SPICE kernels are downloaded directly from ISRO's PRADAN system, SPICE coverage isn't complete so you can download images that do not have kernels available for them yet. Either because PRADAN has no kernels for them or we haven't downloaded them yet as it's a manual process. 
-
-    Check available kernels with the following CURL command: 
+    Chandrayaan 2 SPICE kernels are distributed through the ISIS data area and fetched with `downloadIsisData chandrayaan2 $ISISDATA`. Coverage may still lag for the most recent acquisitions. You can check which kernels are available with the following CURL command: 
 
     ```bash
     curl -XGET "https://astrogeology.usgs.gov/apis/spiceql/latest/searchForKernelsets?spiceqlNames=\[chandrayaan2\]&limitCk=-1&limitSpk=-1" | jq

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ nav:
       - Generating an ISD, creating a CSM model, and converting coordinates: getting-started/csm-stack/image-to-ground-tutorial.ipynb
       - Knoten - Basic Camera Operations:   getting-started/csm-stack/knoten-camera-tutorial.ipynb
       - CSM Sandbox:                        getting-started/csm-stack/csm-sandbox.ipynb
+      - Ingesting Chandrayaan 2 TMC-2 Images: getting-started/csm-stack/ingesting-tmc2.md
+      - Ingesting Chandrayaan 2 OHRC Images:  getting-started/csm-stack/ingesting-ohrc.md
     - Using SpiceQL:
       - SpiceQL Cassini Tutorial:          getting-started/using-spiceql/spiceql-cassini-tutorial.ipynb
       - Exploring SpiceQL's REST, Python, and C++ APIs: getting-started/using-spiceql/exploring-spiceqls-rest-python-and-cpp-apis.md


### PR DESCRIPTION
Add OHRC ingestion docs and fix the install command

## Summary

This adds a new page documenting how to ingest Chandrayaan 2 OHRC images, parallel to the existing TMC-2 page. Previously OHRC ingestion was only linked out to the Ames Stereo Pipeline docs; now it is covered in the Astro docs for both instruments.

- New page `getting-started/csm-stack/ingesting-ohrc.md`. OHRC uses `spiceinit` followed by `isd_generate -k`, which is intentionally different from the TMC-2 `isd_generate -s` path. A note on the page explains why.
- Fix the conda install command on both the OHRC and TMC-2 pages. ISIS 10 is not released yet, so `isis>=10.0.0` does not resolve (release candidates sort before the final release in conda). Pin `isis=10.0.0_RC2` from the `usgs-astrogeology/label/RC` channel, bump `ale` to 1.1.3, and pin `usgscsm=2.0.2`. This command was tested on macOS ARM64 and resolves and installs cleanly, with `spiceql 1.2.7` pulled in as a dependency.
- Update the stale SPICE kernel note on both pages. Kernels are now distributed through the ISIS data area and fetched with `downloadIsisData chandrayaan2`, rather than downloaded manually from PRADAN.
- Add both ingestion pages to the site navigation menu, and add cross-links between the OHRC page, the TMC-2 page, and the Chandrayaan 2 mission page.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
